### PR TITLE
fix: Wrong filenames in different GDrive locales

### DIFF
--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -18,6 +18,7 @@ files_url = "https://drive.google.com/uc?id="
 folder_type = "application/vnd.google-apps.folder"
 
 string_regex = re.compile(r"'((?:[^'\\]|\\.)*)'")
+folder_name_regex = re.compile(r'^[^ ]+')
 
 
 def get_folder_list(folder, quiet=False, use_cookies=True):
@@ -80,7 +81,12 @@ def get_folder_list(folder, quiet=False, use_cookies=True):
 
     folder_contents = [] if folder_arr[0] is None else folder_arr[0]
 
-    folder_list["file_name"] = folder_soup.title.contents[0][:-15]
+    title = folder_soup.title.contents[0]
+    match = folder_name_regex.match(title)
+    if not match:
+        raise ValueError('Folder name not parsed out in {title}')
+
+    folder_list["file_name"] = match.group(0)
     folder_list["file_id"] = folder[39:]
     folder_list["file_type"] = folder_type
     folder_list["file_contents"] = []
@@ -122,6 +128,7 @@ def get_folder_list(folder, quiet=False, use_cookies=True):
             if not return_code:
                 return return_code, None
             folder_list["file_contents"].append(folder_structure)
+
     return return_code, folder_list
 
 


### PR DESCRIPTION
* The various different locales of GDrive can output different titles
  for specific folder. Hence, relying on a specific number of characters
  to strip from the title in order to get to its name is unlikely to
  work reliably.

* This commit tries to instead match all the non-space characters from
  the beginning of the title, in the assumption that this part of the
  title is much less likely to change.

Signed-off-by: mr.Shu <mr@shu.io>